### PR TITLE
Update to use new 'can_connect' method instead of 'is_ready'

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -75,7 +75,7 @@ class PortainerCharm(CharmBase):
         logger.info("updating pebble")
         # get a reference to the portainer workload container
         container = self.unit.get_container(CONTAINER_NAME)
-        if container.is_ready():
+        if container.can_connect():
             svc = container.get_services().get(CONTAINER_NAME, None)
             # check if the pebble service is already running
             if svc:


### PR DESCRIPTION
Due to a recent change in the Operator Framework [PR#605](https://github.com/canonical/operator/pull/605), the `is_ready` method is now renamed `can_connect`. There are some more details in the linked PR, but in this case the use of `is_ready` meant this is a trivial change.